### PR TITLE
Updated markup to fix css breaking Umbraco UI

### DIFF
--- a/src/App_Plugins/GMaps/GMaps.html
+++ b/src/App_Plugins/GMaps/GMaps.html
@@ -19,7 +19,7 @@
         <span>{{formattedAddress}}</span>
     </div>
     <div>
-    	<button type="submit" id="umb-googlemaps-reset-{{model.uid}}" class="btn">
+        <button type="submit" id="umb-googlemaps-reset-{{model.uid}}" class="btn gmaps-reset-btn">
             <gmaps-localize key="resetTxt">Reset position</gmaps-localize>
         </button>
     </div>

--- a/src/App_Plugins/GMaps/assets/css/gmaps.css
+++ b/src/App_Plugins/GMaps/assets/css/gmaps.css
@@ -2,8 +2,8 @@
 	height: 400px;
 }
 
-.btn{
-	margin-top:10px;
+.gmaps-reset-btn {
+	margin-top: 10px;
 }
 
 .hide{

--- a/src/App_Plugins/GMaps/assets/css/gmaps.css
+++ b/src/App_Plugins/GMaps/assets/css/gmaps.css
@@ -2,7 +2,7 @@
 	height: 400px;
 }
 
-.gmaps-reset-btn {
+.btn.gmaps-reset-btn {
 	margin-top: 10px;
 }
 


### PR DESCRIPTION
CSS style for .btn breaks core Umbraco UI (notably the Save and Publish button, see screenshot)
This change just adds another class in the HTML and uses that for styling instead.
![save-and-publish-css](https://user-images.githubusercontent.com/2475647/47632599-b3606980-dbaf-11e8-90db-9cac9cd9f15f.PNG)
