### PR TITLE
Updated ValueConverter to return GMapsLocation rather than object

### DIFF
--- a/src/Models/GMapsLocation.cs
+++ b/src/Models/GMapsLocation.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-
-namespace umbraco_v7_property_editors_gmaps.Models
+﻿namespace umbraco_v7_property_editors_gmaps.Models
 {
-    public struct GMapsLocation
+    public class GMapsLocation
     {
         public decimal Latitude { get; set; }
         public decimal Longitude { get; set; }

--- a/src/ValueConverters/GMapsValueConverter.cs
+++ b/src/ValueConverters/GMapsValueConverter.cs
@@ -1,14 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Web;
+using Umbraco.Core;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.PropertyEditors;
 using umbraco_v7_property_editors_gmaps.Models;
 
 namespace umbraco_v7_property_editors_gmaps.ValueConverters
 {
+    [PropertyValueType(typeof(GMapsLocation))]
     public class GMapsValueConverter : PropertyValueConverterBase
     {
         public override bool IsConverter(PublishedPropertyType propertyType)
@@ -17,6 +16,16 @@ namespace umbraco_v7_property_editors_gmaps.ValueConverters
         }
 
         public override object ConvertDataToSource(PublishedPropertyType propertyType, object source, bool preview)
+        {
+            var convertAttempt = source.TryConvertTo<string>();
+            if (convertAttempt.Success)
+            {
+                return convertAttempt.Result;
+            }
+            return null;
+        }
+
+        public override object ConvertSourceToObject(PublishedPropertyType propertyType, object source, bool preview)
         {
             if (source == null || string.IsNullOrWhiteSpace(source.ToString()))
             {

--- a/src/ValueConverters/GMapsValueConverter.cs
+++ b/src/ValueConverters/GMapsValueConverter.cs
@@ -33,12 +33,20 @@ namespace umbraco_v7_property_editors_gmaps.ValueConverters
             }
 
             string[] coordinates = source.ToString().Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
-
-            return new GMapsLocation
+            
+            decimal lat, lng;
+            if (coordinates.Length == 2 &&
+                decimal.TryParse(coordinates[0], NumberStyles.Number, CultureInfo.InvariantCulture, out lat) && 
+                decimal.TryParse(coordinates[1], NumberStyles.Number, CultureInfo.InvariantCulture, out lng))
             {
-                Latitude = decimal.Parse(coordinates[0], CultureInfo.InvariantCulture),
-                Longitude = decimal.Parse(coordinates[1], CultureInfo.InvariantCulture)
-            };
+                return new GMapsLocation
+                {
+                    Latitude = lat,
+                    Longitude = lng
+                };
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
When using ModelsBuilder, the property returns an object. With this change, the property will return an instance of GMapsLocation instead.